### PR TITLE
Update Invoke-AtomicRunner.ps1 to rename macOS

### DIFF
--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -87,6 +87,12 @@ function Invoke-AtomicRunner {
                 Invoke-Expression $("hostnamectl set-hostname $newHostName")
                 Invoke-Expression $("shutdown -r now")
             }
+	    if ($IsMacOS) {
+                Invoke-Expression $("scutil --set HostName $newHostName")
+                Invoke-Expression $("scutil --set ComputerName $newHostName")
+                Invoke-Expression $("scutil --set LocalHostName $newHostName")
+                Invoke-Expression $("shutdown -r now")
+            }
             else {
                 if ($debug) { LogRunnerMsg "Debug: pretending to rename the computer to $newHostName"; exit }
                 if ($artConfig.gmsaAccount) {


### PR DESCRIPTION
Adding code to the Rename-ThisComputer function to rename MacOS runners using scutil.