### PR TITLE
Update Invoke-SetupAtomicRunner.ps1

### DIFF
--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -82,7 +82,7 @@ function Invoke-SetupAtomicRunner {
     else {
         # sets cronjob string using basepath from config.ps1
         $pwshPath = which pwsh
-        $job = "@reboot root $pwshPath -Command Invoke-KickoffAtomicRunner"
+        $job = "@reboot root sleep 60;$pwshPath -Command Invoke-KickoffAtomicRunner"
         $exists = cat /etc/crontab | Select-String -Quiet "KickoffAtomicRunner"
         #checks if the Kickoff-AtomicRunner job exists. If not appends it to the system crontab.
         if ($null -eq $exists) {


### PR DESCRIPTION
Update Linux Cronjob creation:
adding 60 second delay before cronjob executes. Noticed in some cases network interfaced does not come up in time causing the script to exit in error due to UDP logging not working.